### PR TITLE
Fix email input type in contact form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -86,7 +86,7 @@
                     </div>
                     <div class="input-wrap">
                         <label for="email">Email *</label><br/>
-                        <input id='email' required name='email' type="text">
+                        <input id='email' required name='email' type="email">
                     </div>
                     <div class="input-wrap">
                         <label for="phone">Phone *</label><br/>


### PR DESCRIPTION
## Summary
- use `email` input type for contact form to enable browser validation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ec2782e888322945c3907fcf34a1e