### PR TITLE
Refactor navigation loading and streamline script tags

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -120,6 +120,6 @@
                 <div>September-June : 8:30 a.m. - 4:00 p.m.</div>
             </div>
         </footer>
-        <script src="./main.js" async defer></script>
+        <script src="./main.js" defer></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -241,6 +241,6 @@
             </div>
         </footer>
 
-        <script src="./main.js" async defer></script>
+        <script src="./main.js" defer></script>
     </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ function openFloat() {
 }
 
 // load shared navigation
-document.addEventListener('DOMContentLoaded', () => {
+function loadNav() {
   fetch('./nav.html')
     .then(res => res.text())
     .then(html => {
@@ -27,7 +27,13 @@ document.addEventListener('DOMContentLoaded', () => {
         setActiveNav();
       }
     });
-});
+}
+
+if (document.readyState !== 'loading') {
+  loadNav();
+} else {
+  document.addEventListener('DOMContentLoaded', loadNav);
+}
 
 function setActiveNav() {
   const path = window.location.pathname.split('/').pop();

--- a/parents.html
+++ b/parents.html
@@ -185,6 +185,6 @@
                 <div>September-June : 8:30 a.m. - 4:00 p.m.</div>
             </div>
         </footer>
-        <script src="./main.js" async defer></script>
+        <script src="./main.js" defer></script>
     </body>
 </html>

--- a/programs.html
+++ b/programs.html
@@ -287,6 +287,6 @@
                 <div>September-June : 8:30 a.m. - 4:00 p.m.</div>
             </div>
         </footer>
-        <script src="./main.js" async defer></script>
+        <script src="./main.js" defer></script>
     </body>
 </html>

--- a/success.html
+++ b/success.html
@@ -77,6 +77,6 @@
                 <div>September-June : 8:30 a.m. - 4:00 p.m.</div>
             </div>
         </footer>
-        <script src="./main.js" async defer></script>
+        <script src="./main.js" defer></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- Extract navigation fetch logic into reusable `loadNav()`
- Trigger `loadNav()` on DOM ready without `DOMContentLoaded` wrapper
- Remove unnecessary `async` attribute from script tags across HTML pages

## Testing
- ⚠️ `npm install jsdom --no-save --no-package-lock` *(403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fce9176c8322930f10a4a2ab326b