### PR TITLE
Improve basic SEO markup

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Programs</title>
-        <meta name="description" content="Montessori Lab School of Chesapeake Virginia">
+        <title>Contact Us | Montessori Lab School</title>
+        <meta name="description" content="Contact Montessori Lab School in Chesapeake, Virginia to start enrollment or ask questions">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="./styles.css">
         <link rel="stylesheet" href="./responsive.css">
@@ -28,8 +28,7 @@
     </script>
     <body>
         <header id="nav"></header>
-        
-        
+        <h1 class="sub-header">Contact Montessori Lab School</h1>
         <section class="contact-section">
             <div class="contact-overlay">
             </div>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Montessori Lab School</title>
-        <meta name="description" content="Montessori Lab School of Chesapeake Virginia">
+        <meta name="description" content="Montessori Lab School in Chesapeake, Virginia offering bilingual Christian-oriented education for preschool and elementary students">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="./styles.css">
         <link rel="stylesheet" href="./responsive.css">
@@ -39,7 +39,7 @@
         <section class="head-banner">
                 <div class="head-overlay">
                     <div class="head-content">
-                        <h2 class="main-header">Montessori Lab School</h2>
+                        <h1 class="main-header">Montessori Lab School</h1>
                         <h4>Serving Hampton Roads since 1977</h4>
                         <div class="mission-statements">
                             <p>
@@ -118,20 +118,20 @@
                 <div class="dots-header">Adding to the future success of your child</div>
                 <div class="dots-flex">
                     <div class="dots-letter">
-                        <h1>D</h1>
-                        <span>Decision Making</span>
+                        <span class="letter">D</span>
+                        <span class="description">Decision Making</span>
                     </div>
                     <div class="dots-letter">
-                        <h1>O</h1>
-                        <span>Organization</span>
+                        <span class="letter">O</span>
+                        <span class="description">Organization</span>
                     </div>
                     <div class="dots-letter">
-                        <h1>T</h1>
-                        <span>Time Management</span>
+                        <span class="letter">T</span>
+                        <span class="description">Time Management</span>
                     </div>
                     <div class="dots-letter">
-                        <h1>S</h1>
-                        <span>Self Control</span>
+                        <span class="letter">S</span>
+                        <span class="description">Self Control</span>
                     </div>
                 </div>
             </div>
@@ -173,10 +173,10 @@
         <div class="value-statement">Hampton Road's Longest Running Montessori School.
         </div>
         <section class="credentials">
-            <img class='flex-header' src="./assets/logo.png" alt="">
+            <img class='flex-header' src="./assets/logo.png" alt="Montessori Lab School logo" loading="lazy">
             <div class="flex-container">
-                <img  src="./assets/45 Year Badge.png" alt="">
-                <img src="./assets/namc-badge.png" alt="">
+                <img  src="./assets/45 Year Badge.png" alt="45 year anniversary badge" loading="lazy">
+                <img src="./assets/namc-badge.png" alt="North American Montessori Center badge" loading="lazy">
             </div>
         </section>
         <section class="white-space"></section>

--- a/nav.html
+++ b/nav.html
@@ -1,6 +1,6 @@
 <nav>
     <ul class="nav-bar" id="topNav">
-        <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt="">
+        <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt="Montessori Lab School logo" loading="lazy">
         <li class="nav-logo ">
             <a class='hover-underline-animation' href="./index.html">
                 <span class="long"> Montessori Lab School </span>

--- a/parents.html
+++ b/parents.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Programs</title>
-        <meta name="description" content="Montessori Lab School of Chesapeake Virginia">
+        <title>Parent Resources | Montessori Lab School</title>
+        <meta name="description" content="Resources for Montessori Lab School parents, including Montessori philosophy, school calendar, and recommended reading">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="./styles.css">
         <link rel="stylesheet" href="./responsive.css">
@@ -35,6 +35,7 @@
             </div>
         </div>
         <header id="nav"></header>
+        <h1 class="sub-header">Parent Resources</h1>
         <section class="hero-section">
             <div class="hero-photo hero-2">
                 <div class="photo-overlay">

--- a/programs.html
+++ b/programs.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Programs</title>
-        <meta name="description" content="Montessori Lab School of Chesapeake Virginia">
+        <title>Programs | Montessori Lab School</title>
+        <meta name="description" content="Explore bilingual preschool and elementary programs at Montessori Lab School in Chesapeake, Virginia">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="./styles.css">
         <link rel="stylesheet" href="./responsive.css">
@@ -35,6 +35,7 @@
             </div>
         </div>
         <header id="nav"></header>
+        <h1 class="sub-header">Our Programs</h1>
         <section class="hero-section">
             <div class="hero-photo hero-3">
                 <div class="photo-overlay">
@@ -77,7 +78,7 @@
                                     <img src="./assets/teacher-lesson.jpg" alt="teach lesson">
                                 </div>
                                 <div>
-                                    <img src="./assets/girl-letters.jpg" alt="">
+                                    <img src="./assets/girl-letters.jpg" alt="Child practicing letters" loading="lazy">
                                 </div>
                             </div>
                             <div class="prog-descript">
@@ -113,10 +114,10 @@
                         </div>
                         <div class="program-imgs">
                             <div>
-                                <img src="./assets/Emily.jpg" alt="">
+                                <img src="./assets/Emily.jpg" alt="Student working on classroom activity" loading="lazy">
                             </div>
                             <div>
-                                <img src="./assets/girl-counting.jpg" alt="">
+                                <img src="./assets/girl-counting.jpg" alt="Girl counting beads" loading="lazy">
                             </div>
                         </div>
                         <div class="prog-descript">
@@ -152,13 +153,13 @@
                         
                         <div class="program-imgs">
                             <div>
-                                <img src="./assets/Group.JPG" alt="">
+                                <img src="./assets/Group.JPG" alt="Group of preschool students" loading="lazy">
                             </div>
                             <div>
-                                <img src="./assets/Simon.JPG" alt="">
+                                <img src="./assets/Simon.JPG" alt="Student Simon writing" loading="lazy">
                             </div>
                             <div>
-                                <img src="./assets/boy-letters.jpg" alt="">
+                                <img src="./assets/boy-letters.jpg" alt="Boy working with letters" loading="lazy">
                             </div>
                         </div>
                         <div class="prog-descript">
@@ -202,16 +203,16 @@
                         </div>
                         <div class="program-imgs">
                             <div>
-                                <img src="./assets/girls-cooking.jpg" alt="">
+                                <img src="./assets/girls-cooking.jpg" alt="Elementary students cooking" loading="lazy">
                             </div>
                             <div>
-                                <img src="./assets/elementary-Olivia.JPG" alt="">
+                                <img src="./assets/elementary-Olivia.JPG" alt="Student Olivia studying" loading="lazy">
                             </div>
                             <div>
-                                <img src="./assets/colton.JPG" alt="">
+                                <img src="./assets/colton.JPG" alt="Student Colton reading" loading="lazy">
                             </div>
                             <div>
-                                <img src="./assets/elementary-group.JPG" alt="">
+                                <img src="./assets/elementary-group.JPG" alt="Elementary class group" loading="lazy">
                             </div>
                         </div>
                         <div class="prog-descript">

--- a/styles.css
+++ b/styles.css
@@ -478,11 +478,11 @@ li.icon{
     margin: 2rem 0;
     gap: 2rem;
 }
-.dots-letter h1{
+.dots-letter .letter{
     font-size: 5rem;
     color: var(--dark-red);
 }
-.dots-letter span{
+.dots-letter .description{
     margin-top: 1rem;
     display: block;
     font-size: 2rem;

--- a/success.html
+++ b/success.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>Programs</title>
-        <meta name="description" content="Montessori Lab School of Chesapeake Virginia">
+        <title>Submission Successful | Montessori Lab School</title>
+        <meta name="description" content="Confirmation that your message was sent to Montessori Lab School in Chesapeake, Virginia">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="./styles.css">
         <link rel="stylesheet" href="./responsive.css">
@@ -34,7 +34,7 @@
             <div class="success-overlay">
             </div>
             <div class=" success">
-                <h3 class="sub-header">Successfully Sent!</h3>
+                <h1 class="sub-header">Successfully Sent!</h1>
                 <h5>Someone will get back to you soon!</h5>
                 
             </div>


### PR DESCRIPTION
## Summary
- add page-specific language attributes, titles and meta descriptions
- provide descriptive alt text and lazy-load images
- ensure each page has one meaningful h1 and remove decorative h1 elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b51024775083228327d7be3e396fdd